### PR TITLE
fix: prevent duplicate notification events by adding time-based debouncing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Expo Android NotificationListenerService
 
-<img width="1192" alt="image" src="https://github.com/user-attachments/assets/da45f890-fac7-44ef-91b5-54d62e556110" />
-
+![Jan-17-2025 20-31-53](https://github.com/user-attachments/assets/7a04810e-8c9d-4098-856f-ee813a156a15)
 
 An [Expo module](https://docs.expo.dev/modules/overview/) library that allows Expo app to monitor and interact with notifications from other apps using [NotificationListenerService](https://developer.android.com/reference/android/service/notification/NotificationListenerService).
 

--- a/android/src/main/java/expo/modules/androidnotificationlistenerservice/ExpoAndroidNotificationListenerService.kt
+++ b/android/src/main/java/expo/modules/androidnotificationlistenerservice/ExpoAndroidNotificationListenerService.kt
@@ -5,13 +5,25 @@ import android.service.notification.StatusBarNotification
 import android.app.Notification
 
 class ExpoNotificationListenerService : NotificationListenerService() {
+    private var lastNotificationKey: String? = null
+    private var lastNotificationTime: Long = 0
+
     override fun onNotificationPosted(sbn: StatusBarNotification) {
         val moduleInstance = ExpoAndroidNotificationListenerServiceModule.getInstance() ?: return
         
-        // 패키지 필터링 체크
+    
         if (!moduleInstance.isPackageAllowed(sbn.packageName)) {
             return
         }
+
+        // Delete duplicate notification
+        val currentTime = System.currentTimeMillis()
+        if (sbn.key == lastNotificationKey && currentTime - lastNotificationTime < 500) {
+            return
+        }
+        
+        lastNotificationKey = sbn.key
+        lastNotificationTime = currentTime
 
         val notification = sbn.notification
         val extras = notification.extras


### PR DESCRIPTION
prevent duplicate notification events by adding time-based debouncing(500ms) logic